### PR TITLE
Link to Kick-Off GitHub page, not github.io page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A curated list of awesome UIkit tools and resources. Inspired by [awesome-php](h
 ## Starter Kits
 
 - [UIkit E-commerce Template](https://github.com/chekromul/uikit-ecommerce-template) - E-Commerce Starter Template (Catalog, Filters, Product Page, Shopping Cart and more)
-- [Kick-Off](https://zzseba78.github.io/Kick-Off/) - Quick Starter Template
+- [Kick-Off](https://github.com/zzseba78/Kick-Off) - Quick Starter Template
 - [vuejs-uikit-starter](https://github.com/mstaack/vuejs-uikit-starter) - Quick Starter for Uikit & Vue.js
 
 ## Page Builder and Themes


### PR DESCRIPTION
This makes it easier to dive in and use these templates.